### PR TITLE
ci(dependabot): watch this repo's dependency pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: build
+    groups:
+      npm:
+        patterns: ["*"]


### PR DESCRIPTION
Adds `.github/dependabot.yml` so dependency and action pins in this repo are watched rather than drifting silently.

Ecosystems: github-actions, npm

Grouped and weekly, matching the config style used in `zotgo` and `partspec`. Dependabot alerts and security updates are already enabled here; this covers routine drift.